### PR TITLE
Add partial support for falsy parameters

### DIFF
--- a/src/app/oauth-signature.js
+++ b/src/app/oauth-signature.js
@@ -179,12 +179,15 @@
 			var key;
 			for (key in parameters) {
 				if (parameters.hasOwnProperty(key)) {
-					this._loadParameterValue(key, parameters[key] || '');
+					this._loadParameterValue(key, parameters[key]);
 				}
 			}
 		},
 		_loadParameterValue : function (key, value) {
 			var i;
+			if (value == null) {
+				value = '';
+			}
 			if (value instanceof Array) {
 				for (i = 0; i < value.length; i++) {
 					this._addParameter(key, value[i]);
@@ -213,7 +216,7 @@
 
 	Rfc3986.prototype = {
 		encode : function (decoded) {
-			if (!decoded) {
+			if (decoded == null) {
 				return '';
 			}
 			// using implementation from: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/encodeURIComponent?redirectlocale=en-US&redirectslug=JavaScript%2FReference%2FGlobal_Objects%2FencodeURIComponent


### PR DESCRIPTION
Cause falsy permissive comparisons,  all falsy values are considered `''` when computing the signature  

``` js
var parameters = { 
 a: '',
 b: null,
 c: undefined,
 d: false,
 e: 0,
 f: [],
 g: true,
 h: 1
};
//...
var signature = oauthSignature.generate(httpMethod, url, parameters, consumerSecret, tokenSecret);

//URL used for signature
//a=&b=&c=&d=&e=&f=&g=true&h=1
```

This PR solves the `false` and `0` use case, following the same approach used for `true` and `Number`, creating an URL 

``` js
//a=&b=&c=&d=false&e=0&f=&g=true&h=1
```
