### PR TITLE
uri-js dependency is failing on react-native

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,6 @@
   },
   "dependencies": {
     "crypto-js": "~3.1.5",
-    "uri-js": "^2.1.1"
+    "uri-js": "^3.0.2"
   }
 }


### PR DESCRIPTION
In 3.0.2 version url-js gays fixed error.